### PR TITLE
Changed notification command to be configurable

### DIFF
--- a/autoload/notify_changed.vim
+++ b/autoload/notify_changed.vim
@@ -97,7 +97,8 @@ function! s:check_output(info, _) abort
     let difflines = getbufline(a:info.bufnr, start, linecount)
     let msg = s:truncate_arg(join(difflines))
     let title = s:truncate_arg(bufname(a:info.bufnr))
-    call job_start(['osascript', '-e', 'display notification "' . msg . '" with title "' . title . '"'])
+    let sendmsg = printf("%s with title %s", msg, title)
+    call job_start(printf(g:notify_changed_command, sendmsg))
     if a:info.switch
       call win_gotoid(a:info.winid)
     endif

--- a/plugin/notify_changed.vim
+++ b/plugin/notify_changed.vim
@@ -7,4 +7,14 @@ if v:version < 801
   finish
 endif
 
+if has("mac")
+  let default_command = 'osascript -e "display notification" "%s"'
+elseif has("linux")
+  let default_command = 'notify-send "%s"'
+else
+  let default_command = ''
+endif
+
+let g:notify_changed_command = get(g:, "notify_changed_command", default_command)
+
 command! -nargs=* -complete=customlist,notify_changed#complete NotifyChanged call notify_changed#command([<f-args>])


### PR DESCRIPTION
This pull request is tested on linux only, sorry.

Specify option like this in vimrc:
`let g:notify_changed_command = 'notify_command "%s"'`

”％s" will be replaced to the message